### PR TITLE
Fix UI printing bug for AddRecipe, enable assertions, and add IDE gra…

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="output" path="bin/default"/>
+	<classpathentry output="bin/main" kind="src" path="src/main/java">
+		<attributes>
+			<attribute name="gradle_scope" value="main"/>
+			<attribute name="gradle_used_by_scope" value="main,test"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry output="bin/test" kind="src" path="src/test/java">
+		<attributes>
+			<attribute name="gradle_scope" value="test"/>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17/"/>
+	<classpathentry sourcepath="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-commons/1.10.0/74f2f9694d30effa2caff679b9f02ba832cbd1ac/junit-platform-commons-1.10.0-sources.jar" kind="lib" path="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-commons/1.10.0/d533ff2c286eaf963566f92baf5f8a06628d2609/junit-platform-commons-1.10.0.jar">
+		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-api/5.10.0/551bc33910fee1c601da155a77f67f70f66f6a27/junit-jupiter-api-5.10.0-sources.jar" kind="lib" path="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-api/5.10.0/2fe4ba3d31d5067878e468c96aa039005a9134d3/junit-jupiter-api-5.10.0.jar">
+		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.opentest4j/opentest4j/1.3.0/afb8ff23cffb021c56f333953aebfe6e8818568e/opentest4j-1.3.0-sources.jar" kind="lib" path="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.opentest4j/opentest4j/1.3.0/152ea56b3a72f655d4fd677fc0ef2596c3dd5e6e/opentest4j-1.3.0.jar">
+		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.apiguardian/apiguardian-api/1.1.2/e0787a997746ac32639e0bf3cb27af8dce8a3428/apiguardian-api-1.1.2-sources.jar" kind="lib" path="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.apiguardian/apiguardian-api/1.1.2/a231e0d844d2721b0fa1b238006d15c6ded6842a/apiguardian-api-1.1.2.jar">
+		<attributes>
+			<attribute name="gradle_used_by_scope" value=""/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-engine/1.10.0/886c197f5fcfe9eaf0d1dde20aa1bd3abd653f44/junit-platform-engine-1.10.0-sources.jar" kind="lib" path="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.platform/junit-platform-engine/1.10.0/276c4edcf64fabb5a139fa7b4f99330d7a93b804/junit-platform-engine-1.10.0.jar">
+		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+	<classpathentry sourcepath="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-engine/5.10.0/4fe7a5334478bc8e93bbcb471e24c0fa13520ea7/junit-jupiter-engine-5.10.0-sources.jar" kind="lib" path="C:/Users/kohtz/.gradle/caches/modules-2/files-2.1/org.junit.jupiter/junit-jupiter-engine/5.10.0/90587932d718fc51a48112d33045a18476c542ad/junit-jupiter-engine-5.10.0.jar">
+		<attributes>
+			<attribute name="gradle_used_by_scope" value="test"/>
+			<attribute name="test" value="true"/>
+		</attributes>
+	</classpathentry>
+</classpath>

--- a/.project
+++ b/.project
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>sudocook</name>
+	<comment></comment>
+	<projects/>
+	<natures>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments/>
+		</buildCommand>
+	</buildSpec>
+	<linkedResources/>
+	<filteredResources/>
+</projectDescription>

--- a/.settings/org.eclipse.jdt.core.prefs
+++ b/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,13 @@
+#
+#Sun Mar 15 22:38:35 SGT 2026
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.source=17
+org.eclipse.jdt.core.compiler.debug.localVariable=generate
+org.eclipse.jdt.core.compiler.codegen.unusedLocal=preserve
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.debug.lineNumber=generate
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.debug.sourceFile=generate

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'application'
     id 'checkstyle'
+    id 'eclipse'
     id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
 
@@ -43,4 +44,5 @@ checkstyle {
 
 run{
     standardInput = System.in
+    enableAssertions = true
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'sudocook'

--- a/src/main/java/seedu/sudocook/AddRecipeCommand.java
+++ b/src/main/java/seedu/sudocook/AddRecipeCommand.java
@@ -19,7 +19,7 @@ public class AddRecipeCommand extends Command {
     @Override
     public void execute(RecipeBook recipes) {
         assert(recipes!=null);
-        recipes.addRecipe(name, ingredients, steps);
-
+        Recipe addedRecipe = recipes.addRecipe(name, ingredients, steps);
+        Ui.printMessage("Added recipe:\n" + addedRecipe.toString());
     }
 }

--- a/src/main/java/seedu/sudocook/RecipeBook.java
+++ b/src/main/java/seedu/sudocook/RecipeBook.java
@@ -43,15 +43,15 @@ public class RecipeBook {
         Ui.printMessage(sb.toString());
     }
 
-    public void addRecipe(String name, ArrayList<Ingredient> ingredients, ArrayList<String> steps){
+    public Recipe addRecipe(String name, ArrayList<Ingredient> ingredients, ArrayList<String> steps){
         Recipe newRecipe = new Recipe(name, ingredients, steps);
         recipes.add(newRecipe);
-        Ui.printMessage("Added recipe:\n" + newRecipe.toString());
+        return newRecipe;
     }
 
-    public void addRecipe(Recipe recipe){
+    public Recipe addRecipe(Recipe recipe){
         recipes.add(recipe);
-        Ui.printMessage("Added recipe:\n" + recipe.toString());
+        return recipe;
     }
 
     public int size(){


### PR DESCRIPTION
This pull request merges the `W9TPUpdates` branch into `master` to resolve several minor issues in preparation for the v1.0 release.

### 🐛 Bug Fixes
- **Recipe Print Output**: Fixed a bug where [RecipeBook](cci:2://file:///c:/Users/kohtz/Desktop/tp/src/main/java/seedu/sudocook/RecipeBook.java:4:0-59:1) automatically printed "Added recipe:" globally on startup. The print statement logic was relocated exclusively to the interactive [AddRecipeCommand](cci:2://file:///c:/Users/kohtz/Desktop/tp/src/main/java/seedu/sudocook/AddRecipeCommand.java:4:0-24:1) to ensure clean application initialisation.

### ⚙️ Build & Configuration Updates
- **Defensive Programming**: Enabled assertions (`enableAssertions = true`) in the Gradle [run](cci:1://file:///c:/Users/kohtz/Desktop/tp/src/main/java/seedu/sudocook/SudoCook.java:19:4-39:5) configuration to ensure defensive constraints (e.g., `assert index > 0`) are actively caught during local testing.
- **IDE Compatibility**: Added the Gradle `eclipse` plugin and predefined `rootProject.name` inside [settings.gradle](cci:7://file:///c:/Users/kohtz/Desktop/tp/settings.gradle:0:0-0:0). This generates [.project](cci:7://file:///c:/Users/kohtz/Desktop/tp/.project:0:0-0:0) and [.classpath](cci:7://file:///c:/Users/kohtz/Desktop/tp/.classpath:0:0-0:0) components, allowing VS Code's Java extension to correctly identify the source tree, resolving the false-positive "non-project file" warning markers.
