### PR TITLE
fix: reject malformed filter-r tokens instead of silently ignoring them

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -728,12 +728,16 @@ The feature involves three classes:
 **Step-by-step execution:**
 
 1. The user enters `filter-r [t/MAX_TIME] [c/MAX_CALORIES]`.
-2. `Parser.parse()` detects the `filter-r` prefix and extracts the optional `t/` and `c/` arguments
-   using `Pattern.compile("t/(\\d+)")` and `Pattern.compile("c/(\\d+)")` respectively.
-3. If neither argument is provided, an error is printed and a no-op `Command` is returned.
-4. A `FilterRecipeCommand` is constructed with `maxTime` and `maxCalories` (both nullable `Integer`).
-5. `SudoCook` calls `cmd.execute(recipes)`.
-6. Inside `RecipeBook.filterRecipes(maxTime, maxCalories)`:
+2. `Parser.parse()` detects the `filter-r` prefix and first validates that the entire input
+   consists only of valid `t/DIGITS` and `c/DIGITS` tokens (in any order, with optional whitespace).
+   If any extra text or malformed tokens are detected, an error is printed and a no-op `Command` is
+   returned.
+3. If the input is well-formed, the optional `t/` and `c/` values are extracted using
+   `Pattern.compile("(?i)t/(\\d+)")` and `Pattern.compile("(?i)c/(\\d+)")` respectively.
+4. If neither argument is provided, an error is printed and a no-op `Command` is returned.
+5. A `FilterRecipeCommand` is constructed with `maxTime` and `maxCalories` (both nullable `Integer`).
+6. `SudoCook` calls `cmd.execute(recipes)`.
+7. Inside `RecipeBook.filterRecipes(maxTime, maxCalories)`:
     - Each recipe is checked against both criteria (if provided).
     - A recipe is kept only if its time ≤ `maxTime` (when set) **and** its calories ≤ `maxCalories`
       (when set).

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -497,6 +497,11 @@ Expected output (no filter provided):
 Oops! No valid filter targets provided. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]
 ```
 
+Expected output (malformed or extra tokens in filter):
+```
+Oops! Invalid filter-r format. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]
+```
+
 ---
 
 ### Listing recipes: `list-r`

--- a/src/main/java/seedu/sudocook/Parser.java
+++ b/src/main/java/seedu/sudocook/Parser.java
@@ -353,10 +353,19 @@ public class Parser {
         logger.log(Level.INFO, "Received filter-r request");
         String filterInput = input.substring("filter-r".length()).trim();
 
+        // Validate: the entire input must consist only of t/DIGITS and c/DIGITS tokens,
+        // in any order, with optional whitespace between them. Any extra garbage is rejected.
+        Pattern validFilterPattern = Pattern.compile(
+                "(?i)^(?:\\s*(?:t/\\d+|c/\\d+)\\s*)+$");
+        if (!filterInput.isEmpty() && !validFilterPattern.matcher(filterInput).matches()) {
+            Ui.printError("Invalid filter-r format. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]");
+            return new Command(false);
+        }
+
         Integer maxTime = null;
         Integer maxCalories = null;
 
-        Pattern timePattern = Pattern.compile("t/(\\d+)");
+        Pattern timePattern = Pattern.compile("(?i)t/(\\d+)");
         Matcher timeMatcher = timePattern.matcher(filterInput);
         if (timeMatcher.find()) {
             try {
@@ -367,7 +376,7 @@ public class Parser {
             }
         }
 
-        Pattern caloriePattern = Pattern.compile("c/(\\d+)");
+        Pattern caloriePattern = Pattern.compile("(?i)c/(\\d+)");
         Matcher calorieMatcher = caloriePattern.matcher(filterInput);
         if (calorieMatcher.find()) {
             try {


### PR DESCRIPTION
When filter-r received input like 't/notanumber c/500' or 'filter-r 1/s garbage', the old code used Pattern.find() which silently extracted any valid-looking fragment and ignored the rest, misleading users about which filters were actually applied.

Fix: validate the entire post-command string against a strict whitelist pattern (?i)^(?:\s*(?:t/\d+|c/\d+)\s*)+ before extracting values. Any extra text or malformed tokens now produce an explicit error message.

Also updated DG step-by-step description and added a missing UG expected-output block for the malformed-input case to keep docs consistent with the fixed behaviour.

close #170 