### PR TITLE
fix: PE sweep — 5 bugs and inconsistencies resolved

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -31,9 +31,10 @@ It is a portable, cross-platform tool that keeps all your data local and secure.
 
 Adds a new recipe to the recipe book.
 
-Format: `add-r {NAME} i/INGREDIENT_NAME QUANTITY UNIT [INGREDIENT_NAME QUANTITY UNIT]... s/{STEP_1} [{STEP_2}]... t/TIME_IN_MINUTES c/CALORIES`
+Format: `add-r NAME i/INGREDIENT_NAME QUANTITY UNIT [INGREDIENT_NAME QUANTITY UNIT]... s/STEP_1 [STEP_2]... t/TIME_IN_MINUTES c/CALORIES`
 
-* `NAME` can be wrapped in `{}` to support spaces.
+* Multi-word names and steps must be wrapped in `{}` (e.g. `{Fried Rice}`, `{Cook the rice.}`).
+  Single-word names and steps do not need braces.
 * Each ingredient must be provided in groups of three: `NAME QUANTITY UNIT`.
 * Each ingredient quantity must be a positive number.
 * Ingredients or steps containing spaces should be wrapped in `{}`.
@@ -78,10 +79,6 @@ Expected output (invalid ingredient quantity):
 Oops! Invalid ingredient quantity in add-r format.
 ```
 
-Expected output (zero or negative calories):
-```
-Oops! Calories must be a positive number. A meal cannot have 0 or negative calories.
-```
 
 ---
 

--- a/src/main/java/seedu/sudocook/HelpCommand.java
+++ b/src/main/java/seedu/sudocook/HelpCommand.java
@@ -29,62 +29,71 @@ public class HelpCommand extends Command {
             "   Purpose : Shows full details of all recipes, or a specific recipe by index.\n" +
             "   Example : view-r 1\n\n" +
             "3. Add Recipe\n" +
-            "   Command : add-r {NAME} i/{INGREDIENTS} s/{STEPS} t/{TIME_IN_MINUTES} c/{CALORIES}\n" +
+            "   Command : add-r NAME i/INGREDIENTS s/STEPS t/TIME_IN_MINUTES c/CALORIES\n" +
             "   Example : add-r {Fried Rice} i/rice 2 cups egg 2 pcs {soy sauce} 1 tbsp\n" +
-            "             s/{Cook rice} {Fry eggs} {Mix} t/15 c/450\n\n" +
+            "             s/{Cook rice} {Fry eggs} {Mix} t/15 c/450\n" +
+            "   Note    : TIME and CALORIES must each be between 1 and 100,000.\n\n" +
             "4. Delete Recipe\n" +
-            "   Command : delete-r {INDEX}\n" +
+            "   Command : delete-r INDEX\n" +
             "   Example : delete-r 1\n\n" +
             "5. Filter Recipes\n" +
-            "   Command : filter-r [t/{MAX_TIME_IN_MINUTES}] [c/{MAX_CALORIES}]\n" +
+            "   Command : filter-r [t/MAX_TIME_IN_MINUTES] [c/MAX_CALORIES]\n" +
             "   Example : filter-r t/30\n" +
             "   Example : filter-r c/500\n" +
             "   Example : filter-r t/30 c/500\n\n" +
-            "5a. Search Recipes (Fuzzy)\n" +
-            "   Command : search-r {QUERY}\n" +
+            "6. Search Recipes (Fuzzy)\n" +
+            "   Command : search-r QUERY\n" +
             "   Example : search-r fried rice\n" +
             "   Purpose : Fuzzy search recipes by name (handles typos and partial matches).\n\n" +
-            "5b. Cook Recipe\n" +
-            "   Command : cook {INDEX}\n" +
+            "7. Sort Recipes\n" +
+            "   Command : sort-r n/ | t/ | c/\n" +
+            "   Example : sort-r n/   (alphabetical)\n" +
+            "   Example : sort-r t/   (by time)\n" +
+            "   Example : sort-r c/   (by calories)\n\n" +
+            "8. Cook Recipe\n" +
+            "   Command : cook INDEX\n" +
             "   Example : cook 1\n" +
             "   Purpose : Uses ingredients from inventory to cook the selected recipe.\n\n" +
-            "6. Recommend Recipes\n" +
-            "   Command : recommend-r [n/{INGREDIENT_NAME}]\n" +
+            "9. Recommend Recipes\n" +
+            "   Command : recommend-r [n/INGREDIENT_NAME]\n" +
             "   Example : recommend-r n/egg\n" +
             "   Example : recommend-r\n" +
             "   Purpose : Recommend available recipes based on specific ingredient or current inventory.\n\n" +
-            "   Command : recommend-r missing/{N}\n" +
+            "   Command : recommend-r missing/N\n" +
             "   Example : recommend-r missing/2\n" +
             "   Purpose : Show recipes missing at most N ingredients, with exact shortfall per item.\n\n" +
             "INGREDIENT COMMANDS:\n" +
             "--------------------------------------------------------\n" +
-            "7. List Ingredients\n" +
-            "   Command : list-i [ex/{YYYY-MM-DD}]\n" +
+            "10. List Ingredients\n" +
+            "   Command : list-i [ex/YYYY-MM-DD]\n" +
             "   Example : list-i ex/2026-04-01\n" +
             "   Purpose : Shows all ingredients, or only those expiring before the given date.\n\n" +
-            "8. Add Ingredient\n" +
-            "   Command : add-i n/{NAME} q/{QUANTITY} u/{UNIT} [ex/{YYYY-MM-DD}]\n" +
+            "11. Add Ingredient\n" +
+            "   Command : add-i n/NAME q/QUANTITY u/UNIT [ex/YYYY-MM-DD]\n" +
             "   Example : add-i n/Apple q/5 u/pcs\n" +
             "   Example : add-i n/Milk q/1 u/carton ex/2026-04-10\n\n" +
-            "9. Delete Ingredient\n" +
-            "   Command : delete-i {INDEX|NAME} [{QUANTITY}]\n" +
+            "12. Delete Ingredient\n" +
+            "   Command : delete-i INDEX/NAME [QUANTITY]\n" +
             "   Example : delete-i 1\n" +
             "   Example : delete-i Apple\n" +
             "   Example : delete-i Apple 2\n" +
             "   Purpose : Deletes the indexed ingredient, or the first ingredient matching the name.\n\n" +
-            "9a. Search Ingredients (Fuzzy)\n" +
-            "   Command : search-i {QUERY}\n" +
+            "13. Search Ingredients (Fuzzy)\n" +
+            "   Command : search-i QUERY\n" +
             "   Example : search-i tomato\n" +
             "   Purpose : Fuzzy search ingredients by name (handles typos and partial matches).\n\n" +
-            "9b. Sort Ingredients\n" +
+            "14. Sort Ingredients\n" +
             "   Command : sort-i\n" +
             "   Purpose : Sorts inventory by expiry date, with items without expiry shown last.\n\n" +
             "OTHER:\n" +
             "--------------------------------------------------------\n" +
-            "10. Help\n" +
+            "15. Undo\n" +
+            "   Command : undo\n" +
+            "   Purpose : Reverts the most recent command that modified the inventory or recipes.\n\n" +
+            "16. Help\n" +
             "   Command : help\n" +
             "   Purpose : Displays this help guide.\n\n" +
-            "11. Exit\n" +
+            "17. Exit\n" +
             "   Command : bye\n" +
             "   Purpose : Exits SudoCook.\n\n" +
             "========================================================";

--- a/src/main/java/seedu/sudocook/Parser.java
+++ b/src/main/java/seedu/sudocook/Parser.java
@@ -369,9 +369,14 @@ public class Parser {
         Matcher timeMatcher = timePattern.matcher(filterInput);
         if (timeMatcher.find()) {
             try {
-                maxTime = Integer.parseInt(timeMatcher.group(1));
+                long timeLong = Long.parseLong(timeMatcher.group(1));
+                if (timeLong < 0 || timeLong > Integer.MAX_VALUE) {
+                    Ui.printError("Invalid filter-r format. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]");
+                    return new Command(false);
+                }
+                maxTime = (int) timeLong;
             } catch (NumberFormatException e) {
-                Ui.printError("Invalid time format for filter-r.");
+                Ui.printError("Invalid filter-r format. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]");
                 return new Command(false);
             }
         }
@@ -380,9 +385,14 @@ public class Parser {
         Matcher calorieMatcher = caloriePattern.matcher(filterInput);
         if (calorieMatcher.find()) {
             try {
-                maxCalories = Integer.parseInt(calorieMatcher.group(1));
+                long calorieLong = Long.parseLong(calorieMatcher.group(1));
+                if (calorieLong < 0 || calorieLong > Integer.MAX_VALUE) {
+                    Ui.printError("Invalid filter-r format. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]");
+                    return new Command(false);
+                }
+                maxCalories = (int) calorieLong;
             } catch (NumberFormatException e) {
-                Ui.printError("Invalid calorie format for filter-r.");
+                Ui.printError("Invalid filter-r format. Use: filter-r [t/MAX_TIME] [c/MAX_CALORIES]");
                 return new Command(false);
             }
         }

--- a/src/main/java/seedu/sudocook/RecipeBook.java
+++ b/src/main/java/seedu/sudocook/RecipeBook.java
@@ -22,13 +22,11 @@ public class RecipeBook {
     }
 
     public Recipe getRecipe(int index){
-
-        try {
-            return recipes.get(index);
-        } catch (IndexOutOfBoundsException exception) {
+        if (index < 0 || index >= recipes.size()) {
             Ui.printError("Index out of bounds");
             return null;
         }
+        return recipes.get(index);
     }
 
     public void listRecipe() {

--- a/src/main/java/seedu/sudocook/SudoCook.java
+++ b/src/main/java/seedu/sudocook/SudoCook.java
@@ -45,7 +45,7 @@ public class SudoCook {
 
         Command cmd;
         String input = ui.readInput();
-        while (!input.equals("bye")) {
+        while (!input.equalsIgnoreCase("bye")) {
             if (input.isBlank()) {
                 logger.log(Level.FINE, "Empty input received, skipping");
                 input = ui.readInput();
@@ -77,9 +77,11 @@ public class SudoCook {
                 cmd.execute(inventory); // Execute on either, it just prints UI
             } else if (cmd instanceof CookCommand) {
                 logger.log(Level.FINE, "Routing cook command");
-                commandHistory.saveSnapshot(recipes, inventory);
-                cmd.execute(recipes.getRecipe(cmd.getIndex()), inventory);
-
+                Recipe recipe = recipes.getRecipe(cmd.getIndex());
+                if (recipe != null) {
+                    commandHistory.saveSnapshot(recipes, inventory);
+                    cmd.execute(recipe, inventory);
+                }
             } else if (cmd instanceof RecommendByIngredientCommand || cmd instanceof RecommendByInventoryCommand
                     || cmd instanceof RecommendByMissingCommand) {
                 logger.log(Level.FINE, "Routing recommend command");


### PR DESCRIPTION
1. [Critical] cook INDEX out-of-range now prints error instead of silently failing. RecipeBook.getRecipe() adds an explicit bounds check before calling recipes.get(), ensuring the UG-documented error message appears.

2. [High] filter-r overflow: switched to Long.parseLong for t/ and c/ values to prevent crash on very large digit strings (mirrors add-r fix).

3. [High] help command: added missing sort-r and undo entries; fixed non-standard 5a/5b/9a/9b numbering to sequential 1-17; removed spurious braces from command format strings.

4. [High] UG: removed stale expected-output block for add-r with zero or negative calories (that error message is no longer reachable with the new range-check logic).

5. [Medium] UG: clarified that braces in add-r NAME/STEP are only required for multi-word tokens, not mandatory syntax.